### PR TITLE
Add support for refreshing lock lease

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 replace github.com/docker/docker v23.0.5+incompatible => github.com/docker/docker v23.0.7-0.20230730020554-801e90549aac+incompatible
 
 require (
+	github.com/benbjohnson/clock v1.3.5
 	github.com/redis/go-redis/v9 v9.0.4
 	github.com/stretchr/testify v1.8.2
 	github.com/testcontainers/testcontainers-go v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VM
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/hcsshim v0.9.7 h1:mKNHW/Xvv1aFH87Jb6ERDzXTJTLPlmzfZ28VBFD/bfg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
+github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bsm/ginkgo/v2 v2.7.0 h1:ItPMPH90RbmZJt5GtkcNvIRuGEdwlBItdNVoyzaNQao=
 github.com/bsm/gomega v1.26.0 h1:LhQm+AFcgV2M0WyKroMASzAzCAJVpAxQXv4SaI9a69Y=
 github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=

--- a/mutex/mutex.go
+++ b/mutex/mutex.go
@@ -22,11 +22,19 @@ const unlockScript = `
 	redis.call('del', KEYS[1]);
 	return 1;
 `
+const extendScript = `
+	if (redis.call('exists', KEYS[1]) == 1) then
+		redis.call('pexpire', KEYS[1], ARGV[1]);
+		return 1;
+	end;
+	return 0;
+`
 
 type Mutex struct {
-	client        redis.UniversalClient
-	key           string
-	leaseDuration time.Duration
+	client                  redis.UniversalClient
+	key                     string
+	leaseDuration           time.Duration
+	leaseExtenderCancelFunc context.CancelFunc
 }
 
 type Options struct {
@@ -70,14 +78,73 @@ func (m *Mutex) doTryLock(ctx context.Context) (int64, error) {
 		return 0, err
 	}
 
+	// If lock was acquired, kick off lease extender
+	if ttl == 0 {
+		go m.launchLeaseExtender()
+	}
+
 	return ttl, nil
 }
 
 func (m *Mutex) Unlock(ctx context.Context) error {
-	_, err := m.client.Eval(ctx, unlockScript, []string{m.key}, m.leaseDuration.Milliseconds()).Int64()
+	_, err := m.client.Eval(ctx, unlockScript, []string{m.key}).Int64()
 	if err != nil {
 		return fmt.Errorf("unlocked failed: %w", err)
 	}
 
 	return nil
+}
+
+func (m *Mutex) launchLeaseExtender() {
+	// Use a fresh root context here so that we explicitly manage the cancellation
+	leaseExtenderCtx, cancelFunc := context.WithCancel(context.Background())
+	m.leaseExtenderCancelFunc = cancelFunc
+	m.leaseExtensionLoop(leaseExtenderCtx)
+}
+
+func (m *Mutex) leaseExtensionLoop(ctx context.Context) {
+	ticker := time.NewTicker(m.leaseDuration / 3)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			success, err := m.extendLease(ctx)
+			if err != nil {
+				//FIXME log
+				return
+			}
+
+			// lock no longer exists so shut down the goroutine
+			if !success {
+				if m.leaseExtenderCancelFunc != nil {
+					m.leaseExtenderCancelFunc()
+				}
+				return
+			}
+		case <-ctx.Done():
+			// Context has been cancelled. Nothing to do...
+			return
+		}
+	}
+}
+
+func (m *Mutex) extendLease(ctx context.Context) (bool, error) {
+	result, err := m.client.Eval(ctx, extendScript, []string{m.key}, m.leaseDuration.Milliseconds()).Int64()
+
+	if err != nil {
+		return false, fmt.Errorf("extending lease: %w", err)
+	}
+
+	if result == 1 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (m *Mutex) stopLeaseExtender() {
+	if m.leaseExtenderCancelFunc != nil {
+		m.leaseExtenderCancelFunc()
+	}
 }


### PR DESCRIPTION
This pull request updates the locking code to automatically extend a lease on the redis entry while the lock is held by the user. This allows the user to use locks without estimating the maximum amount of time they may need to hold the lock for. 